### PR TITLE
Fix: Resolve TypeError DB.prepare is not a function in first-play-fre…

### DIFF
--- a/src/lib/test-db-holder.ts
+++ b/src/lib/test-db-holder.ts
@@ -1,0 +1,16 @@
+import { D1Database } from '@cloudflare/workers-types';
+
+// Define a basic structure for the D1 mock, aligning with what tests might provide.
+// This could be expanded or made more generic if needed.
+export interface D1DatabaseMock {
+  prepare: jest.Mock<any, any>;
+  dump?: jest.Mock<any, any>;
+  batch?: jest.Mock<any, any>;
+  transaction?: jest.Mock<any, any>;
+  // Add other methods your mockD1 might have and that the D1Database type expects,
+  // or ensure your mockD1 conforms to D1Database for stricter typing.
+}
+
+export const testDbHolder: { instance: D1Database | D1DatabaseMock | null } = {
+  instance: null,
+};

--- a/tests/integration/first-play-free.test.ts
+++ b/tests/integration/first-play-free.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { createServer, IncomingMessage, ServerResponse } from 'http';
 import firstPlayFreeHandler from '../../src/pages/api/first-play-free';
+import { testDbHolder } from '../../src/lib/test-db-holder';
 import { creditConfigService, ICreditConfigService, CreditConfig } from '../../src/services/CreditConfigService';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { JwtPayload, VerifyOptions, JsonWebTokenError } from 'jsonwebtoken'; // Import VerifyOptions and JsonWebTokenError
@@ -148,7 +149,8 @@ describe('/api/first-play-free', () => {
   beforeAll(() => {
     process.env.NODE_ENV = 'test';
     process.env.PARTICLE_NETWORK_JWT_SECRET = 'supersecretjwtkeythatisatleast32characterslong';
-    (process.env as any).DB = mockD1;
+    // (process.env as any).DB = mockD1; // Old way
+    testDbHolder.instance = mockD1;
 
     // Set up the default implementation for mockD1.prepare once here
     // This will be the fallback if a test doesn't use mockImplementationOnce
@@ -169,6 +171,7 @@ describe('/api/first-play-free', () => {
 
   afterAll((done) => {
     process.env = { ...ORIGINAL_ENV };
+    testDbHolder.instance = null; // Clean up
     server.close(done);
   });
 
@@ -300,6 +303,14 @@ describe('/api/first-play-free', () => {
         id: 'first-play-free', name: 'First Play Free', rules: { amount: 0.005 },
         created_at: new Date().toISOString(), updated_at: new Date().toISOString()
     });
+
+    // Diagnostic logs
+    // Diagnostic logs (removed)
+    // console.log('Test File - mockD1:', mockD1);
+    // console.log('Test File - typeof mockD1.prepare:', typeof mockD1.prepare);
+    // console.log('Test File - mockD1.prepare is mock:', jest.isMockFunction(mockD1.prepare));
+    // console.log('Test File - process.env.DB === mockD1:', (process.env as any).DB === mockD1);
+
 
     const res = await agent.post('/api/first-play-free').send({ userToken: 'token_grant_new' }); // Unique token
 


### PR DESCRIPTION
…e API tests

- Implemented testDbHolder to correctly inject mock D1 instance into the API handler during tests, replacing the unreliable process.env method.
- Created src/lib/test-db-holder.ts.
- Updated tests/integration/first-play-free.test.ts to use testDbHolder.
- Updated src/pages/api/first-play-free.ts to consume DB mock from testDbHolder in test environment.
- All tests in first-play-free.test.ts are now passing.